### PR TITLE
Implement error ToString helper

### DIFF
--- a/dryad/src/errors.cpp
+++ b/dryad/src/errors.cpp
@@ -3,7 +3,7 @@
 namespace Dryad
 {
 
-    const char* dryad_error_string(Error error)
+    const char* ToString(Error error)
     {
         switch (error)
         {
@@ -19,6 +19,8 @@ namespace Dryad
             case InvalidPosition: return "invalid position";
             case InvalidMotifNote: return "invalid motif note";
             case InvalidEdge: return "invalid edge";
+            case InvalidDegree: return "invalid degree";
+            case InvalidScale: return "invalid scale";
             case Invalid: return "invalid value";
         }
     }


### PR DESCRIPTION
## Summary
- implement `Dryad::ToString(Error)` and provide string messages for all error codes

## Testing
- `cmake --build .`
- `./tests/tests`


------
https://chatgpt.com/codex/tasks/task_e_689b3b17ad008329b34c0197f9fdce35