### PR TITLE
Fix missing Octave definition in scale header

### DIFF
--- a/dryad/src/scale.h
+++ b/dryad/src/scale.h
@@ -2,6 +2,7 @@
 
 #include "chord.h"
 #include "graph.h"
+#include "constants.h"
 
 namespace Dryad
 {


### PR DESCRIPTION
## Summary
- include `constants.h` in `scale.h` so the Octave constant is defined

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6289994d4832998a7a9ce96b653d9