### PR TITLE
Fix degree indexing and implement score serialization

### DIFF
--- a/dryad/src/chord.h
+++ b/dryad/src/chord.h
@@ -20,9 +20,9 @@ namespace Dryad
         Fifth = Dominant,
         Submediant = 5,
         Sixth = Submediant,
-        LeadingTone = 7,
+        LeadingTone = 6,
         Seventh = LeadingTone,
-        Limit = 8, 
+        Limit = 7,
         Invalid = -1
     };
 

--- a/dryad/src/constants.h
+++ b/dryad/src/constants.h
@@ -40,7 +40,7 @@ namespace Dryad
     constexpr int ScaleLimit = 12;
     constexpr int OctaveLimit = 11;
     constexpr int MiddleOctave = 4;
-    constexpr int DegreesPerOctave = static_cast<int>(Degree::Limit) - 1;
+    constexpr int DegreesPerOctave = static_cast<int>(Degree::Limit);
 
     constexpr float Frequencies[ScaleLimit][OctaveLimit] =
     {

--- a/dryad/src/serialize.h
+++ b/dryad/src/serialize.h
@@ -16,7 +16,7 @@ namespace Dryad
     {
         String name;
         int id;
-        Vector<SerializedVoice> notes;
+        Vector<SerializedNote> notes;
     };
 
     struct SerializedScore

--- a/dryad/src/voice.cpp
+++ b/dryad/src/voice.cpp
@@ -34,8 +34,24 @@ namespace Dryad
 
     MotifInstance* Voice::getLastMotifInstance()
     {
-        // TODO : implement
-        return nullptr;
+        MotifInstance* lastInstance = nullptr;
+        Time lastEnd = 0;
+
+        for (Motif* motif : motifs)
+        {
+            MotifInstance* instance = motif->getLastInstance();
+            if (!instance)
+                continue;
+
+            Time end = instance->getEndTime();
+            if (end > lastEnd)
+            {
+                lastEnd = end;
+                lastInstance = instance;
+            }
+        }
+
+        return lastInstance;
     }
 
     Error Voice::generateUntil(Time positionTarget)


### PR DESCRIPTION
## Summary
- correct `Degree` enum to prevent out-of-bounds scale indexing
- add ability for voices to track last motif instance and link instances to motifs/voices
- implement score dumping and serialized structures

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a637fd8c808329af0133c44a206acf