### PR TITLE
Implement motif removal, timing helper, and progression init

### DIFF
--- a/dryad/src/motif.cpp
+++ b/dryad/src/motif.cpp
@@ -94,7 +94,41 @@ namespace Dryad
 
     Error Motif::getInstancesEndTime(Voice* voice, Time& time)
     {
-        return NotImplemented;
+        if (!voice)
+            return InvalidVoice;
+
+        if (!graph->contains(voice))
+            return NodeNotInGraph;
+
+        time = 0;
+        bool foundInstance = false;
+
+        forEachEdge<MotifInstance>([&](MotifInstance* instance)
+            {
+                Voice* instanceVoice = instance->findFirstEdge<Voice>();
+                if (instanceVoice != voice)
+                    return;
+
+                Time end = instance->getEndTime();
+                if (end == Invalid)
+                {
+                    time = Invalid;
+                    return;
+                }
+
+                if (end > time)
+                    time = end;
+
+                foundInstance = true;
+            });
+
+        if (!foundInstance)
+            time = 0;
+
+        if (time == Invalid)
+            return InvalidMotifInstance;
+
+        return Success;
     }
 
     MotifInstance::MotifInstance(Time position)

--- a/dryad/src/score.cpp
+++ b/dryad/src/score.cpp
@@ -32,7 +32,15 @@ namespace Dryad
 
     Chord ScoreFrame::getCurrentChord()
     {
-        return getScore()->currentProgression->currentProgressionChord->chord;
+        Score* score = getScore();
+        if (!score || !score->currentProgression)
+            return Chord();
+
+        ProgressionChord* chord = score->currentProgression->currentProgressionChord;
+        if (!chord)
+            return Chord();
+
+        return chord->chord;
     }
 
     Error ScoreFrame::addMotifNote(MotifNote* motifNote)
@@ -194,6 +202,13 @@ namespace Dryad
             frame = getOrCreateFrame(0);
 
         Time relativePosition = frame->relativePosition + durationToCommit;
+
+        if (currentProgression && !currentProgression->currentProgressionChord)
+        {
+            if (currentProgression->entryNode)
+                currentProgression->currentProgressionChord =
+                    currentProgression->entryNode->get<ProgressionChord>();
+        }
 
         // For every motif of each voice, generate instances until the total committed
         // duration is reached

--- a/dryad/src/voice.cpp
+++ b/dryad/src/voice.cpp
@@ -29,7 +29,20 @@ namespace Dryad
 
     Error Voice::removeMotif(Motif* motif)
     {
-        return NotImplemented;
+        if (!graph->contains(motif))
+            return NodeNotInGraph;
+
+        auto it = std::find(motifs.begin(), motifs.end(), motif);
+        if (it == motifs.end())
+            return InvalidMotif;
+
+        // Remove linkage between this voice and the motif
+        removeEdge(motif);
+        motif->removeEdge(this);
+
+        motifs.erase(it);
+
+        return Success;
     }
 
     MotifInstance* Voice::getLastMotifInstance()


### PR DESCRIPTION
## Summary
- implement `Voice::removeMotif` to unlink motifs and update cache
- add `Motif::getInstancesEndTime` to compute last instance end time
- initialize current progression chord during commit and guard chord lookup to prevent crashes

## Testing
- `cmake .. && cmake --build .` (from `build` dir)
- `./tests/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a71dfa1bac8329bbcd9bea3475e208